### PR TITLE
update the spinner to not grab the very bottom view of the stack

### DIFF
--- a/MFCard/Card /Helper Class/LBZSpinner.swift
+++ b/MFCard/Card /Helper Class/LBZSpinner.swift
@@ -301,6 +301,9 @@ import UIKit
 
     // find usable superview
     fileprivate func findLastUsableSuperview() -> UIView {
+        if let last = UIApplication.shared.keyWindow?.subviews.last as UIView?{
+            return last
+        }
         return (window?.subviews[0])!
     }
 


### PR DESCRIPTION
i really don't know anything about the spinner class or the consequence of this change. Take or leave it, but it satisfies my needs of placing this component in a modal view that rides high on the view stack